### PR TITLE
Added check on fetch order from checkout session

### DIFF
--- a/src/module-elasticsuite-tracker/Block/Variables/Page/Order.php
+++ b/src/module-elasticsuite-tracker/Block/Variables/Page/Order.php
@@ -65,7 +65,7 @@ class Order extends \Smile\ElasticsuiteTracker\Block\Variables\Page\AbstractBloc
 
         $order = $order = $this->checkoutSession->getLastRealOrder();
 
-        if ($order) {
+        if ($order && $order->getIncrementId()) {
             $variables['order.subtotal']        = $order->getBaseSubtotalInclTax();
             $variables['order.discount_total']  = $order->getDiscountAmount();
             $variables['order.shipping_total']  = $order->getShippingAmount();


### PR DESCRIPTION
This pull request contains a check to avoid errors like:
`Error: Call to a member function getMethod() on null in /var/www/html/vendor/smile/elasticsuite/src/module-elasticsuite-tracker/Block/Variables/Page/Order.php:74`

This could happen when the object returned from the checkout session by [getLastRealOrder](https://github.com/magento/magento2/blob/2.4.1/app/code/Magento/Checkout/Model/Session.php#L531) method is an empty Order class.
